### PR TITLE
Fix/#82 history background

### DIFF
--- a/app/src/main/java/com/nexters/zzallang/harusal2/ui/history/HistoryViewAdapter.kt
+++ b/app/src/main/java/com/nexters/zzallang/harusal2/ui/history/HistoryViewAdapter.kt
@@ -119,6 +119,7 @@ class HistoryViewAdapter(private val context: Context, private val onedayBudget:
                     } else {
                         ""
                     }.plus(historyStatement.money)
+                        .plus("원")
 
                 layout.findViewById<TextView>(R.id.tv_content).text = historyStatement.content
 
@@ -140,12 +141,6 @@ class HistoryViewAdapter(private val context: Context, private val onedayBudget:
                 item.income > 0 -> "+"
                 else -> ""
             } + """${item.income}원"""
-
-            if (-item.spending > onedayBudget) {
-                binding.tvSpending.setTextColor(context.getColor(R.color.colorSpendColor))
-            } else {
-                binding.tvSpending.setTextColor(context.getColor(R.color.colorDarkBlack))
-            }
 
             binding.tvSpending.text =  "${item.spending}원"
 

--- a/app/src/main/java/com/nexters/zzallang/harusal2/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/nexters/zzallang/harusal2/ui/history/HistoryViewModel.kt
@@ -44,18 +44,12 @@ class HistoryViewModel(
 
         val safeMoney = this.oneDayBudget * DateUtils.calculateDate(budget.startDate, endDate)
         val spentMoney = -spentMoney
-        return if (spentMoney < safeMoney * 0.9) {
-            SpendState.FLEX
-        } else if (spentMoney < safeMoney * 0.95) {
-            SpendState.CLAP
-        } else if (spentMoney < safeMoney * 1.04) {
-            SpendState.DEFAULT
-        } else if (spentMoney < safeMoney * 1.1) {
-            SpendState.EMBARRASSED
-        } else if (spentMoney < safeMoney * 1.15) {
-            SpendState.CRY
-        } else {
-            SpendState.VOLCANO
+        return when {
+            spentMoney > safeMoney * 1.8 -> SpendState.VOLCANO
+            spentMoney > safeMoney * 1.4 -> SpendState.CRY
+            spentMoney > safeMoney * 1.1 -> SpendState.EMBARRASSED
+            spentMoney > safeMoney * 0.3 -> SpendState.CLAP
+            else -> SpendState.FLEX
         }
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28971015/97169738-e608c100-17cd-11eb-883b-a69a66d026c6.png)
- 변경된 값을 적용하였습니다
- ex) 1~30일까지 있을 때, 30만원이면 5일일 경우, 하루에 쓸 수 있는 돈 10000원, 지금까지 쓴 돈 28,000원
10000 * 5가 쓸 수 있는 돈으로 해서, 5만원으로 현재 쓴 돈을 계산합니다.
28000 : 50000의 비율로 계산합니다